### PR TITLE
<p> tags not getting added from Classic Editor.

### DIFF
--- a/admin/settings-callbacks.php
+++ b/admin/settings-callbacks.php
@@ -18,19 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 
 /**
- * Print/echo the dashboard about message.
- * 
- * @since 1.0.0
- */
-function sapphire_popups_callback_section_dashboard_about() {
-	
-	echo '<p>' . esc_html__( 'All about this plugin maybe some meta data...', 'sapphire-popups' ) . '</p>';
-
-}
-
-
-
-/**
  * Print/echo the Popup section message.
  *
  * @return void

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,12 @@
-= 1.0.0: August 30th, 2020 =
+## 1.0.0: 2020-08-30
 * Created version 1.
+
+## [1.0.1] - 2020-09-16
+
+### Fixed
+
+- Added the_content filter on popup content so that it can be treated the same way as a normal post.
+- The issue was that <p> tags were not being added so all lines ended up on one line. The wpautop filter which added <p> tags is one of the filters used in the_content so I just used that.
+- I also used wp_kses_post for extra sanitization when pulling from the DB but this removes custom HTML. I found that get_post_by_title() uses get_post() which uses sanitize_post() so this is happening by default.
+- includes > core-functions.php > sapphire_popups_add_popup_script.
+- 

--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -34,10 +34,10 @@ function sapphire_popups_add_popup_script() {
 		
 		// Get the popup from the custom post type - popups.
 		$popup = get_page_by_title( $options['select_popup'], OBJECT, 'sapphire_popups' );
-		$popupContent = __( apply_filters( 'the_content',  wp_kses_post($popup->post_content) ), 'sapphire-popups' );
+		$popupContent = __( apply_filters( 'the_content',  $popup->post_content ), 'sapphire-popups' );
 
 		// Get the popup behavior from the DB.
-		$popupBehavior = isset( $options['select_popup_behavior'] ) ? $options['select_popup_behavior'] : '';
+		$popupBehavior = isset( $options['select_popup_behavior'] ) ? esc_html__( wp_kses_post($options['select_popup_behavior']), 'sapphire-popups' ) : '';
 
 		// See if the title will be excluded or included - default is included.
 		$popupTitle = isset( $options['exclude_popup_title'] ) ? '' : '<h2 class="popup-title">' . get_the_title( $popup->ID ) . '</h2>';

--- a/sapphire-popus.php
+++ b/sapphire-popus.php
@@ -5,7 +5,7 @@ Description: A simple yet powerful solution for popups.
 Plugin URI:  https://github.com/runningCoder81/sapphire-popups
 Author:      Bobby Lee
 Author URI:  https://therunningcoder.com/
-Version:     1.0.0
+Version:     1.0.1
 Text Domain: sapphire-popups
 Domain Path: /languages
 License:     GPL v2 or later
@@ -100,30 +100,3 @@ function sapphire_popups_add_settings_link( $links ) {
 
 $filter_name = "plugin_action_links_" . plugin_basename( __FILE__ );
 add_filter( $filter_name, 'sapphire_popups_add_settings_link' );
-
-
-
-/**
- * Add iFrame to allowed wp_kses_post tags
- *
- * @param array  $tags Allowed tags, attributes, and/or entities.
- * @param string $context Context to judge allowed tags by. Allowed values are 'post'.
- *
- * @return array
- */
-function custom_wpkses_post_tags( $tags, $context ) {
-
-	if ( 'post' === $context ) {
-		$tags['iframe'] = array(
-			'src'             => true,
-			'height'          => true,
-			'width'           => true,
-			'frameborder'     => true,
-			'allowfullscreen' => true,
-		);
-	}
-
-	return $tags;
-}
-
-add_filter( 'wp_kses_allowed_html', 'custom_wpkses_post_tags', 10, 2 );


### PR DESCRIPTION
- Added the_content filter on popup content so that it can be treated the same way as a normal post.
- The issue was that <p> tags were not being added so all lines ended up on one line. The wpautop filter which added <p> tags is one of the filters used in the_content so I just used that.
- I also used wp_kses_post for extra sanitization when pulling from the DB but this removes custom HTML. I found that get_post_by_title() uses get_post() which uses sanitize_post() so this is happening by default.
- includes > core-functions.php > sapphire_popups_add_popup_script.